### PR TITLE
added sec headers to requests

### DIFF
--- a/api/constants/constants.ts
+++ b/api/constants/constants.ts
@@ -5,5 +5,6 @@ export const constants = {
     REJECT_IPS: [],
     SANITIZE_FIELDS_LOGGING: ['password', 'user_pass', 'user_hash'],
     SALT_VALUE: 'This is totally secure.',
+    CSRF_SECRET: 'O4471uCRC0hZSYZ_5Z9RKQlY',
     SESSION_COOKIE: 'G_SESSION_ID'
 };

--- a/api/constants/constants.ts
+++ b/api/constants/constants.ts
@@ -5,6 +5,5 @@ export const constants = {
     REJECT_IPS: [],
     SANITIZE_FIELDS_LOGGING: ['password', 'user_pass', 'user_hash'],
     SALT_VALUE: 'This is totally secure.',
-    CSRF_SECRET: 'O4471uCRC0hZSYZ_5Z9RKQlY',
     SESSION_COOKIE: 'G_SESSION_ID'
 };

--- a/api/middlewares.ts
+++ b/api/middlewares.ts
@@ -9,7 +9,7 @@ const filename = basename(__filename);
 
 // tslint:disable-next-line: no-var-requires
 const tokens = require('csrf')();
-const secret = constants.CSRF_SECRET;
+const secret = tokens.secretSync();
 
 const buildErrorResponse = (res: Response, code: number, errorCode: string, errorMessage?: string) => {
     res.status(code).send({

--- a/api/services/distance/distanceService.ts
+++ b/api/services/distance/distanceService.ts
@@ -15,7 +15,7 @@ class DistanceService {
             grubberLogger.debug('Distance service request is ', { filename, obj: req });
             const zipCodes = await mySqlService.retrieveZipCodes(req.zipOne, req.zipTwo);
             grubberLogger.debug('Response from database ', { filename, obj: zipCodes });
-            if (req.measure !== 'miles' || req.measure !== 'km') {
+            if (req.measure !== 'miles' && req.measure !== 'km') {
                 throw {
                     status: 400,
                     error: {

--- a/app/package.json
+++ b/app/package.json
@@ -3,10 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.5.0",
-    "@testing-library/user-event": "^7.2.1",
+    "axios": "0.20.0",
     "bootstrap": "^4.5.2",
+    "crypto-js": "4.0.0",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <meta name="referrer" content="no-referrer-when-downgrade	">
     <meta
       name="description"
       content="Web site created using create-react-app"

--- a/app/src/services/HttpInterceptor/HttpInterceptor.js
+++ b/app/src/services/HttpInterceptor/HttpInterceptor.js
@@ -1,0 +1,46 @@
+
+import Axios from 'axios';
+import StorageService from '../SessionStorageService/SessionStorageService';
+import { AES } from 'crypto-js';
+
+const interceptor = () => {
+    
+    // Intercept api requests and append security token
+    Axios.interceptors.request.use(
+        (req) => {
+            if (req.url.includes('/api')) {
+                req.headers['CSRF-TOKEN'] = StorageService.get('csrfToken');
+                req.headers['GRUBBER-SEC-TOKEN'] = generateSecToken();
+            }
+            return req;
+        },
+        (error) => {
+            return Promise.reject(error);
+        }
+    );
+
+    // Intercept api responses and store csrf token
+    Axios.interceptors.response.use(
+        (res) => {
+            if (res.headers['csrf-token']) {
+                StorageService.set('csrfToken', res.headers['csrf-token']);
+            }
+            return Promise.resolve(res);
+        },
+        (error) => {
+            return Promise.reject(error);
+        }
+    );
+};
+
+const generateSecToken = () => {
+    const curr = new Date();
+    const exp = new Date();
+    exp.setMilliseconds(curr.getMilliseconds() + 3000);
+    const obj = {
+        msg: exp.toUTCString()
+    };
+    return AES.encrypt(JSON.stringify(obj), 'Si je veux bien').toString();
+}
+
+export default { interceptor };

--- a/app/src/services/HttpService/HttpService.js
+++ b/app/src/services/HttpService/HttpService.js
@@ -1,0 +1,28 @@
+
+import Axios from 'axios';
+import Interceptor from '../HttpInterceptor/HttpInterceptor';
+
+Interceptor.interceptor();
+
+const requestGet = (url, opts) => {
+    return Axios.get(url, opts);
+};
+
+const requestPost = (url, body, opts) => {
+    return Axios.post(url, body, opts);
+};
+
+const requestPut = (url, body, opts) => {
+    return Axios.put(url, body, opts);
+}
+
+const requestDelete = (url, opts) => {
+    return Axios.delete(url, opts);
+}
+
+export default {
+    requestGet,
+    requestPost,
+    requestPut,
+    requestDelete
+};

--- a/app/src/services/SessionStorageService/SessionStorageService.js
+++ b/app/src/services/SessionStorageService/SessionStorageService.js
@@ -1,0 +1,18 @@
+
+const get = (key) => {
+    return sessionStorage.getItem(key);
+};
+
+const set = (key, value) => {
+    sessionStorage.setItem(key, value);
+};
+
+const remove = (key) => {
+    sessionStorage.removeItem(key);
+};
+
+export default {
+    get,
+    set,
+    remove
+}


### PR DESCRIPTION
In the front end added an http service and interceptor so that all requests will send csrf token and security token in headers.
I used axios when creating these, if we wanted to use another library for http requests I can update this to use that library.

I also moved the testing dependencies in the front end into the devDependencies node. This is to make building the project more efficient. This is mostly for deploying, when we build we don't always want to install testing dependencies and separating them in the package.json allows us to ignore these.